### PR TITLE
Fix delete request API

### DIFF
--- a/memc.go
+++ b/memc.go
@@ -61,7 +61,9 @@ func (conn *Connection) MemSet(key string, value []byte, expires uint32) error {
 func (conn *Connection) MemDelete(key string) error {
 	_, err := conn.Execute(&Delete{
 		Space: conn.memcacheSpace,
-		Value: Bytes(key),
+		Tuple: Tuple{
+			[]byte(key),
+		},
 	})
 
 	return err

--- a/pack.go
+++ b/pack.go
@@ -321,14 +321,7 @@ func (q *Delete) Pack(requestID uint32, defaultSpace uint32) ([]byte, error) {
 		bodyBuffer.Write(packedInt0)
 	}
 
-	if q.Value != nil {
-		bodyBuffer.Write(packTuple(Tuple{q.Value}))
-	} else if q.Values != nil {
-		cnt := len(q.Values)
-		for i := 0; i < cnt; i++ {
-			bodyBuffer.Write(packTuple(Tuple{q.Values[i]}))
-		}
-	}
+	bodyBuffer.Write(packTuple(q.Tuple))
 
 	buffer.Write(PackInt(requestTypeDelete))
 	buffer.Write(PackInt(uint32(bodyBuffer.Len())))

--- a/tnt.go
+++ b/tnt.go
@@ -82,7 +82,7 @@ type Insert struct {
 type OpCode uint8
 
 const (
-	opSet    OpCode = iota
+	opSet OpCode = iota
 	opAdd
 	opAnd
 	opXor
@@ -93,15 +93,15 @@ const (
 )
 
 func OpSet(field uint32, value Bytes) Operator {
-	return Operator{field, opSet,value}
+	return Operator{field, opSet, value}
 }
 
 func OpDelete(field uint32, value Bytes) Operator {
-	return Operator{field, opDelete,value}
+	return Operator{field, opDelete, value}
 }
 
 func OpInsert(field uint32, value Bytes) Operator {
-	return Operator{field, opInsert,value}
+	return Operator{field, opInsert, value}
 }
 
 type Operator struct {
@@ -118,20 +118,10 @@ type Update struct {
 }
 
 type Delete struct {
-	// Scalar
-	// This request is looking for one single record
-	Value Bytes
-
-	// List of scalars
-	// This request is looking for several records using single-valued index
-	// Ex: select(space_no, index_no, [1, 2, 3])
-	// Transform a list of scalar values to a list of tuples
-	Values []Bytes
+	Tuple Tuple
 
 	Space       interface{}
 	ReturnTuple bool
-
-	// Index  uint32
 }
 
 type Call struct {


### PR DESCRIPTION
Currently `Delete` request looks like a Copy&Paste from `Select` request, and it doesn't allow to delete a record identified by a composite id. 

I.e.
```
space[0]:delete{a,b,c}
```

This PR changes the API by replacing Delete's `Value` and `Values` fields with the single `Tuple` field, so the request would be in alignment with Update.