### PR TITLE
connection: Use sync.Pool for request-bound objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-Tarantool 1.5 connector
+# github.com/lomik/go-tnt
+
+Tarantool 1.5 connector.
+
+## Running tests
+
+```
+% go test -short ./...
+```
+
+To test Tarantool interconnection one must have a test tarantool 1.5 instance running on the primary port 2001.
+Start a Docker container defined in `tarantool/Dockerfile`:
+
+```
+% make -C tarantool build run
+docker build -t tarantool15-test ./
+...
+docker run -ti --rm -p 2001:2001 tarantool15-test
+...
+```
+
+Run full test suites:
+
+```
+% go test ./...
+```

--- a/bench_test.go
+++ b/bench_test.go
@@ -3,7 +3,6 @@ package tnt
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"testing"
 )
@@ -34,27 +33,6 @@ func BenchmarkPackIntAlt1(b *testing.B) {
 		body := new(bytes.Buffer)
 		binary.Write(body, binary.LittleEndian, value)
 		body.Bytes()
-	}
-}
-
-func BenchmarkSelect(b *testing.B) {
-	b.SkipNow()
-
-	primaryPort, tearDown, err := setUp()
-	defer tearDown()
-
-	conn, err := Connect(fmt.Sprintf("127.0.0.1:%d", primaryPort), nil)
-	defer conn.Close()
-
-	if err != nil {
-		b.FailNow()
-	}
-
-	for n := 0; n < b.N; n++ {
-		conn.Execute(&Select{
-			Value: PackInt(0),
-			Space: 10,
-		})
 	}
 }
 

--- a/memc_test.go
+++ b/memc_test.go
@@ -11,8 +11,10 @@ import (
 func TestMem(t *testing.T) {
 	assert := assert.New(t)
 
-	primaryPort, tearDown, err := setUp()
-	assert.NoError(err)
+	primaryPort, tearDown := setUp(t)
+	if t.Skipped() {
+		return
+	}
 	defer tearDown()
 
 	conn, err := Connect(fmt.Sprintf("127.0.0.1:%d", primaryPort), nil)

--- a/tarantool/Dockerfile
+++ b/tarantool/Dockerfile
@@ -1,12 +1,9 @@
-FROM centos:centos7
+FROM tarantool/tarantool:1.5
 
-RUN yum install scl-utils -y
-RUN rpm -i http://tarantool.org/dist/master/centos/7/os/x86_64/Packages/mailru-15-runtime-1.0-1.noarch.rpm http://tarantool.org/dist/master/centos/7/os/x86_64/Packages/mailru-15-tarantool-1.5.5-9.x86_64.rpm
-
-ADD tarantool.cfg /usr/local/etc/tarantool.cfg
-
-RUN /opt/tarantool/mailru-15/root/bin/tarantool_box --config /usr/local/etc/tarantool.cfg --init-storage
+COPY tarantool.cfg /usr/local/etc/tarantool.cfg
+WORKDIR /data/tarantool/
+RUN chown -R tarantool:tarantool /data/tarantool/ \
+    && su-exec tarantool tarantool_box --config /usr/local/etc/tarantool.cfg --init-storage
 
 EXPOSE 2001
-
-ENTRYPOINT ["/opt/tarantool/mailru-15/root/bin/tarantool_box", "--config", "/usr/local/etc/tarantool.cfg"]
+ENTRYPOINT ["su-exec", "tarantool", "tarantool_box", "--config", "/usr/local/etc/tarantool.cfg"]

--- a/tarantool/Makefile
+++ b/tarantool/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t tarantool ./
+	docker build -t tarantool15-test ./
 
 run:
-	docker run -ti --rm -p 2001:2001 tarantool
+	docker run -ti --rm -p 2001:2001 tarantool15-test

--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,27 @@
+package tnt
+
+import (
+	"sync"
+	"time"
+)
+
+var timerPool sync.Pool
+
+func acquireTimer(d time.Duration) *time.Timer {
+	v := timerPool.Get()
+	if v == nil {
+		return time.NewTimer(d)
+	}
+	tm := v.(*time.Timer)
+	if tm.Reset(d) {
+		panic("timerPool: got active timer")
+	}
+	return tm
+}
+
+func releaseTimer(tm *time.Timer) {
+	if !tm.Stop() {
+		return
+	}
+	timerPool.Put(tm)
+}

--- a/tnt.go
+++ b/tnt.go
@@ -169,7 +169,6 @@ type Connection struct {
 }
 
 func (conn *Connection) ExecuteOptions(q Query, opts *QueryOptions) (result []Tuple, err error) {
-
 	reqID, request, err := conn.newRequest(q)
 	if err != nil {
 		return
@@ -189,8 +188,8 @@ func (conn *Connection) ExecuteOptions(q Query, opts *QueryOptions) (result []Tu
 	}
 
 	// set execute deadline
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
+	deadline := acquireTimer(timeout)
+	defer releaseTimer(deadline)
 
 	select {
 	case conn.requestChan <- request:

--- a/tnt_test.go
+++ b/tnt_test.go
@@ -1,0 +1,28 @@
+package tnt
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+var testTntPrimaryPort int
+
+type testingT interface {
+	SkipNow()
+}
+
+func setUp(t testingT) (int, func()) {
+	if testing.Short() {
+		t.SkipNow()
+		return 0, func() {}
+	}
+	return testTntPrimaryPort, func() {}
+}
+
+func TestMain(t *testing.M) {
+	flag.IntVar(&testTntPrimaryPort, "test.tarantool_primary_port", 2001, "primary port for test tarantool")
+	flag.Parse()
+
+	os.Exit(t.Run())
+}


### PR DESCRIPTION
This PR reduces the number of objects allocated in `Exec()` method by using `sync.Pool` for `request` and request's `deadline` timers.

In addition to that, I've fixed tests which were broken due to compilation errors.

Here are the benchmarks of making `Select` request.

Before:

```
% go test -run XX -bench 'BenchmarkSelect$' -benchmem
goos: darwin
goarch: amd64
pkg: github.com/lomik/go-tnt
BenchmarkSelect-4       	    5000	    215051 ns/op	     579 B/op	      12 allocs/op
PASS
```

After:

```
% go test -run XX -bench 'BenchmarkSelect$' -benchmem
goos: darwin
goarch: amd64
pkg: github.com/lomik/go-tnt
BenchmarkSelect-4   	   10000	    187894 ns/op	     237 B/op	       6 allocs/op
PASS
```