### PR TITLE
optimize query pack

### DIFF
--- a/pack_test.go
+++ b/pack_test.go
@@ -170,17 +170,6 @@ func TestPackIntBase128(t *testing.T) {
 	}
 }
 
-func TestPackFieldInt(t *testing.T) {
-	assert := assert.New(t)
-
-	for value := range values(32) {
-		assert.Equal(
-			pythonIproto("pack_int(%d)", value),
-			packFieldInt(uint32(value)),
-		)
-	}
-}
-
 func TestPackFieldStr(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pack_test.go
+++ b/pack_test.go
@@ -173,15 +173,22 @@ func TestPackIntBase128(t *testing.T) {
 func TestPackFieldStr(t *testing.T) {
 	assert := assert.New(t)
 
+	out := make([]byte, base128len(len("hello_world")))
+	packFieldStr([]byte("hello_world"), out)
+
 	assert.Equal(
 		pythonIproto("pack_str(\"%s\")", "hello_world"),
-		packFieldStr([]byte("hello_world")),
+		out,
 	)
 
 	for value := range values(64) {
+		val := Bytes(fmt.Sprintf("%d", value))
+		out := make([]byte, base128len(len(val)))
+		packFieldStr(val, out)
+
 		assert.Equal(
 			pythonIproto("pack_str(\"%d\")", value),
-			packFieldStr(Bytes(fmt.Sprintf("%d", value))),
+			out,
 		)
 	}
 }


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: constructor/tests
BenchmarkCallBefore-4            1000000              1546 ns/op             920 B/op         17 allocs/op
BenchmarkCallAfter-4            10000000               218 ns/op              80 B/op          2 allocs/op
BenchmarkDeleteBefore-4          1000000              1386 ns/op             808 B/op         16 allocs/op
BenchmarkDeleteAfter-4          10000000               205 ns/op              80 B/op          2 allocs/op
BenchmarkUpdateBefore-4          1000000              1918 ns/op            1020 B/op         22 allocs/op
BenchmarkUpdateAfter-4           5000000               267 ns/op             112 B/op          2 allocs/op
BenchmarkInsertBefore-4          1000000              1344 ns/op             808 B/op         16 allocs/op
BenchmarkInsertAfter-4          10000000               206 ns/op              80 B/op          2 allocs/op
BenchmarkSelect1Before-4        10000000               136 ns/op              49 B/op          2 allocs/op
BenchmarkSelect1After-4         20000000                97.1 ns/op            48 B/op          1 allocs/op
BenchmarkSelect2Before-4         5000000               272 ns/op              84 B/op          5 allocs/op
BenchmarkSelect2After-4         10000000               169 ns/op              80 B/op          1 allocs/op
BenchmarkSelect3Before-4         5000000               281 ns/op              84 B/op          5 allocs/op
BenchmarkSelect3After-4         10000000               180 ns/op              80 B/op          1 allocs/op
```