### PR TITLE
fix rare case of broken box

### DIFF
--- a/box.go
+++ b/box.go
@@ -143,14 +143,14 @@ START_LOOP:
 
 	WAIT_LOOP:
 		for {
-			if strings.Contains(boxStderrBuffer.String(), "entering event loop") {
-				break START_LOOP
-			}
-
 			if strings.Contains(boxStderrBuffer.String(), "is already in use, will retry binding after") {
 				cmd.Process.Kill()
 				cmd.Process.Wait()
 				break WAIT_LOOP
+			}
+
+			if strings.Contains(boxStderrBuffer.String(), "entering event loop") {
+				break START_LOOP
 			}
 
 			n, err := boxStderr.Read(p)


### PR DESCRIPTION
example of a problem log:
```
$ cat /tmp/1267842349/log.txt
2022-11-02 23:17:11.347 [11107] 1/sched I> Mapping 1077936128 bytes for a shared arena
2022-11-02 23:17:11.347 [11107] 1/sched C> version 1.5.5-19-gf5090a2
2022-11-02 23:17:11.347 [11109] 1/spawner C> initialized
2022-11-02 23:17:11.349 [11107] 1/sched I> space 0 successfully configured
2022-11-02 23:17:11.349 [11107] 1/sched I> recovery start
2022-11-02 23:17:11.349 [11107] 1/sched I> recover from `snap/00000000000000000001.snap'
2022-11-02 23:17:11.349 [11107] 1/sched D> log_io_cursor_next: marker:0x00000000BA0BABED/4
2022-11-02 23:17:11.349 [11107] 1/sched D> eof while looking for magic
2022-11-02 23:17:11.349 [11107] 1/sched I> snapshot recovered, confirmed lsn: 1
2022-11-02 23:17:11.349 [11107] 1/sched I> building secondary indexes
2022-11-02 23:17:11.349 [11107] 1/sched I> bound to memcached port 8034, ip INADDR_ANY
2022-11-02 23:17:11.349 [11107] 1/sched evio.cc:336 W> primary port 8033 is already in use, will retry binding after 0.100000 seconds.
2022-11-02 23:17:11.349 [11107] 1/sched I> bound to admin port 8035, ip INADDR_ANY
2022-11-02 23:17:11.349 [11107] 1/sched evio.cc:336 W> replication port 8036 is already in use, will retry binding after 0.100000 seconds.
2022-11-02 23:17:11.350 [11107] 101/init.lua I> loading ./init.lua
2022-11-02 23:17:11.350 [11107] 1/sched C> log level 6
2022-11-02 23:17:11.350 [11107] 1/sched C> entering event loop
```
such a box doesn't work:
```
$ tarantool15 --host 127.0.0.1 --port 8033
error: Unknown ERROR, Connection reset by peer (errno: 104)
```